### PR TITLE
Update to use command-line-arguments v2.0.0

### DIFF
--- a/src/eval-server.lisp
+++ b/src/eval-server.lisp
@@ -811,7 +811,9 @@
              slave
              slave-buffer
              background-buffer
-             (backend-type hi::*default-backend*))
+             (backend-type hi::*default-backend*)
+             backend tty clx qt)
+  (declare (ignorable backend tty clx qt))
   (assert slave)
   (let ((hi::*connection-backend*
          (ecase backend-type

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -387,7 +387,8 @@ GB
 (defun hemlock (&optional x
                 &key (load-user-init t)
                      backend-type
-                     (display (isys:getenv "DISPLAY")))
+                     (display (isys:getenv "DISPLAY"))
+                     backend tty clx qt)
   "Invokes the editor, Hemlock.  If X is supplied and is a symbol, the
    definition of X is put into a buffer, and that buffer is selected.  If X is
    a pathname, the file specified by X is visited in a new buffer.  If X is not
@@ -398,6 +399,7 @@ GB
    different name.  Any compiled version of the source is preferred when
    choosing the file to load.  If the argument is non-nil and not t, then it
    should be a pathname that will be merged with the home directory."
+  (declare (ignorable backend tty clx qt))
   (cond
     (*in-the-editor*
      (process-command-line-argument x))


### PR DESCRIPTION
The command-line-arguments package version 2 changed it's handling of
arguments in a backwards incompatible way.  The return value of any
:action functions defined on arguments are now saved as the new value
of the argument in the returned `*command-line-arguments*'.

This commit updates hemlock so that it defines and ignores these new
keyword arguments when they are passed through to the `hemlock' and
`%start-slave' functions.  This preservers the old behavior.